### PR TITLE
Hotfix/UI lox route

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,10 +6,11 @@
   status = 200
   force = true
 
-# Proxy Lox interpreter API to avoid CORS
+# Proxy Lox interpreter API via Netlify Function so the upstream
+# Render API never sees an Origin header (which it rejects with 403).
 [[redirects]]
-  from   = "/api/lox/*"
-  to     = "https://lox-core-api.onrender.com/api/:splat"
+  from   = "/api/lox/execute"
+  to     = "/.netlify/functions/lox-execute"
   status = 200
   force  = true
 

--- a/netlify/functions/lox-execute.js
+++ b/netlify/functions/lox-execute.js
@@ -1,0 +1,32 @@
+const LOX_API = 'https://lox-core-api.onrender.com/api/execute'
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Method Not Allowed' }),
+    }
+  }
+
+  try {
+    const upstream = await fetch(LOX_API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: event.body,
+    })
+
+    const text = await upstream.text()
+    return {
+      statusCode: upstream.status,
+      headers: { 'Content-Type': 'application/json' },
+      body: text,
+    }
+  } catch (err) {
+    return {
+      statusCode: 502,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'upstream_error', message: err.message }),
+    }
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,11 @@ export default defineConfig({
         target: 'https://lox-core-api.onrender.com',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api\/lox/, '/api'),
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq) => {
+            proxyReq.removeHeader('origin')
+          })
+        },
       },
     },
   },


### PR DESCRIPTION
fix: Lox interpreter returning CORS error in production and local dev

Root cause: The Render API rejects any HTTP request that includes an Origin header with 403 Invalid CORS request. Netlify's redirect proxy was transparently forwarding the browser's Origin header to Render, causing every execution request to fail. The same issue affected local dev because Vite's proxy also forwarded the browser-set Origin header.

Changes:

Replaced the Netlify redirect for /api/lox/* with a Netlify Function (netlify/functions/lox-execute.js) that makes a clean server-to-server request to Render with no Origin header
Added a proxyReq hook to the Vite dev proxy to strip the Origin header before forwarding, fixing the same issue locally