### PR TITLE
PR: Dark Mode Toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/heart.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Drizzywhiz</title>
+    <script>
+      (function() {
+        try {
+          if (localStorage.getItem('theme') === 'dark') document.documentElement.classList.add('dark');
+        } catch(e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,24 +1,40 @@
-// import React from 'react'
-import { Route, BrowserRouter as Router, Routes } from 'react-router-dom'
+import { useEffect } from 'react'
+import { Route, BrowserRouter as Router, Routes, useLocation } from 'react-router-dom'
+import { ThemeProvider, useTheme } from './context/ThemeContext'
 import Navbar from './components/Navbar'
 import { Home, About, AboutExperience, Blog, Projects, Contact, Interpreter } from './pages'
 
+function RouteAwareDark({ children }) {
+  const { isDark } = useTheme()
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', isDark && pathname !== '/')
+  }, [isDark, pathname])
+
+  return children
+}
+
 const App = () => {
   return (
-    <main className="bg-slate-300/20 h-full">
-      <Router>
-        <Navbar />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/about/experience" element={<AboutExperience />} />
-          <Route path="/blog" element={<Blog />} />
-          <Route path="/projects" element={<Projects />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route path="/interpreter" element={<Interpreter />} />
-        </Routes>
-      </Router>
-    </main>
+    <ThemeProvider>
+      <main className="bg-slate-300/20 h-full dark:bg-slate-900 transition-colors duration-300">
+        <Router>
+          <RouteAwareDark>
+            <Navbar />
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/about" element={<About />} />
+              <Route path="/about/experience" element={<AboutExperience />} />
+              <Route path="/blog" element={<Blog />} />
+              <Route path="/projects" element={<Projects />} />
+              <Route path="/contact" element={<Contact />} />
+              <Route path="/interpreter" element={<Interpreter />} />
+            </Routes>
+          </RouteAwareDark>
+        </Router>
+      </main>
+    </ThemeProvider>
   )
 }
 

--- a/src/components/CTA.jsx
+++ b/src/components/CTA.jsx
@@ -4,9 +4,9 @@ import { Link } from 'react-router-dom'
 const CTA = () => {
   return (
     <section className='cta'>
-        <p className='cta-text'>Have a project in mind? 
+        <p className='cta-text'>Have a project in mind?
             <br className='sm:block hidden'/>
-            <span className='text-black-500 font-medium'>Let's build something together!</span>
+            <span className='text-black-500 dark:text-slate-300 font-medium'>Let's build something together!</span>
         </p>
         <Link to="/contact" className='btn'>
             Contact

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,25 +1,64 @@
-import { NavLink } from "react-router-dom"
+import { NavLink, useLocation } from "react-router-dom"
+import { useTheme } from '../context/ThemeContext'
 
 const Navbar = () => {
+  const { isDark, toggleTheme } = useTheme()
+  const { pathname } = useLocation()
+  const isHome = pathname === '/'
+
   return (
     <header className="header relative z-50">
-        <NavLink to="/" className="w-10 h-10 rounded-lg bg-white items-center 
-                                    justify-center flex font-bold shadow-md">
-            
-            <p className="blue-gradient_text">AM</p>
+      <NavLink
+        to="/"
+        className="w-10 h-10 rounded-lg bg-white dark:bg-slate-800 dark:border dark:border-slate-600
+                   items-center justify-center flex font-bold shadow-md transition-colors duration-300"
+      >
+        <p className="blue-gradient_text">AM</p>
+      </NavLink>
+
+      <nav className="flex text-lg gap-7 font-medium items-center relative z-20">
+        <NavLink
+          to="/about"
+          className={({ isActive }) => isActive ? 'text-blue-500 font-bold' : 'text-lime-400 hover:text-lime-300 transition-colors'}
+          style={{ textShadow: '1px 1px 2px rgba(0,0,0,0.5)' }}
+        >
+          About
         </NavLink>
-        <nav className="flex text-lg gap-7 font-medium relative z-20">
-            <NavLink to="/about" className={({ isActive }) => isActive? 'text-blue-500 font-bold': 'text-lime-400 hover:text-lime-300 transition-colors'} style={{textShadow: '1px 1px 2px rgba(0,0,0,0.5)'}}>
-                About 
-            </NavLink>
-            <NavLink to="/projects" className={({ isActive }) => isActive? 'text-blue-500 font-bold': 'text-lime-400 hover:text-lime-300 transition-colors'} style={{textShadow: '1px 1px 2px rgba(0,0,0,0.5)'}}>
-                Projects
-            </NavLink>
-            <NavLink to="/contact" className={({ isActive }) => isActive? 'text-blue-500 font-bold': 'text-lime-400 hover:text-lime-300 transition-colors'} style={{textShadow: '1px 1px 2px rgba(0,0,0,0.5)'}}>
-                Contact
-            </NavLink>
-        </nav>
-        
+        <NavLink
+          to="/projects"
+          className={({ isActive }) => isActive ? 'text-blue-500 font-bold' : 'text-lime-400 hover:text-lime-300 transition-colors'}
+          style={{ textShadow: '1px 1px 2px rgba(0,0,0,0.5)' }}
+        >
+          Projects
+        </NavLink>
+        <NavLink
+          to="/contact"
+          className={({ isActive }) => isActive ? 'text-blue-500 font-bold' : 'text-lime-400 hover:text-lime-300 transition-colors'}
+          style={{ textShadow: '1px 1px 2px rgba(0,0,0,0.5)' }}
+        >
+          Contact
+        </NavLink>
+
+        {!isHome && (
+          <button
+            onClick={toggleTheme}
+            aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+            className="w-9 h-9 flex items-center justify-center rounded-lg
+                       bg-white/80 dark:bg-slate-700 border border-slate-200 dark:border-slate-600
+                       hover:scale-105 transition-all duration-200 shadow-sm"
+          >
+            {isDark ? (
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M12 8a4 4 0 100 8 4 4 0 000-8z" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 text-slate-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+              </svg>
+            )}
+          </button>
+        )}
+      </nav>
     </header>
   )
 }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -255,7 +255,7 @@ export const projects = [
         theme: 'btn-back-blue',
         name: 'HylyTool Chrome Extension',
         description: 'Built a lightweight, privacy-first Chrome extension to make studying and reading online more focused. With just a click, you can blur out distracting content or highlight important text using custom colors. Features a clean popup UI, persistent settings with Chrome Sync, and a snappy user experience, keeping speed and simplicity in mind.',
-        link: 'https://github.com/adrianhajdin/project_next13_car_showcase',
+        link: 'https://chromewebstore.google.com/detail/hylytool/nobfjmbpgjmimofjmgomnnojenplfmgm',
     },
     // {
     //     iconUrl: snapgram,

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const ThemeContext = createContext(null)
+
+export function ThemeProvider({ children }) {
+  const [isDark, setIsDark] = useState(() => {
+    try { return localStorage.getItem('theme') === 'dark' } catch { return false }
+  })
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', isDark)
+    try { localStorage.setItem('theme', isDark ? 'dark' : 'light') } catch {}
+  }, [isDark])
+
+  return (
+    <ThemeContext.Provider value={{ isDark, toggleTheme: () => setIsDark(p => !p) }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => useContext(ThemeContext)

--- a/src/index.css
+++ b/src/index.css
@@ -182,7 +182,20 @@ body:has(.card[data-color="green"]:hover) {
     0.65vmin 1vmin #d2e4ff, 1vmin 0.65vmin #d2e4ff;
 }
 
+/* Suppress the light glow on skill/project icon cards in dark mode */
+.dark .block-container .btn-back {
+  box-shadow: 16px 0 40px rgba(0, 0, 0, 0.4);
+}
+
 /* Dark mode overrides for utility classes that can't take inline dark: modifiers */
+.dark .head-text {
+  @apply text-white;
+}
+
+.dark .subhead-text {
+  @apply text-white;
+}
+
 .dark .input,
 .dark .textarea {
   @apply bg-slate-800 border-slate-600 text-slate-100 focus:ring-blue-400 focus:border-blue-400;

--- a/src/index.css
+++ b/src/index.css
@@ -181,3 +181,13 @@ body:has(.card[data-color="green"]:hover) {
   box-shadow: 0.6vmin 0.6vmin #fff, 1vmin 1vmin #d2e4ff, 1vmin 1vmin #d2e4ff,
     0.65vmin 1vmin #d2e4ff, 1vmin 0.65vmin #d2e4ff;
 }
+
+/* Dark mode overrides for utility classes that can't take inline dark: modifiers */
+.dark .input,
+.dark .textarea {
+  @apply bg-slate-800 border-slate-600 text-slate-100 focus:ring-blue-400 focus:border-blue-400;
+}
+
+.dark .cta-text {
+  @apply text-slate-300;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,10 @@ body {
   font-family: "Work Sans", sans-serif;
 }
 
+*, *::before, *::after {
+  transition: color 250ms ease, background-color 250ms ease, border-color 250ms ease;
+}
+
 body:has(.card[data-color="blue"]:hover) {
   background-color: rgb(var(--blue-rgb) / 25%);
 }

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -14,7 +14,7 @@ const About = () => {
         <a
           href="/Adriza_resume.pdf"
           download="Adriza_Resume.pdf"
-          className='inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-500/10 border border-blue-400/30 hover:bg-blue-500/20 hover:border-blue-400/50 transition-all duration-200 text-blue-600 font-medium text-sm shrink-0'
+          className='inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-blue-500/10 border border-blue-400/30 hover:bg-blue-500/20 hover:border-blue-400/50 dark:bg-blue-500/20 dark:border-blue-500/40 dark:hover:bg-blue-500/30 transition-all duration-200 text-blue-600 dark:text-blue-400 font-medium text-sm shrink-0'
         >
           <img src={download} className='w-4 h-4' alt="" />
           Download Resume
@@ -30,7 +30,7 @@ const About = () => {
             className='w-64 h-64 lg:w-72 lg:h-72 object-cover rounded-2xl shadow-lg border-2 border-blue-200/50'
           />
         </div>
-        <div className='flex-1 flex flex-col gap-4 text-slate-600'>
+        <div className='flex-1 flex flex-col gap-4 text-slate-600 dark:text-slate-300'>
           <p className='text-lg leading-relaxed'>
           Software Engineer based in India who gets excited about hard problems. From optimizing gnarly systems to untangling complex architectures, I'm happiest when I'm deep in research mode, hunting for that elegant solution.
           </p>
@@ -47,15 +47,15 @@ const About = () => {
       <div className='mt-16 grid sm:grid-cols-2 gap-6'>
         <Link
           to="/about/experience"
-          className='group flex flex-col p-6 rounded-xl bg-blue-500/10 border border-blue-400/30 hover:bg-blue-500/20 hover:border-blue-400/50 transition-all duration-200'
+          className='group flex flex-col p-6 rounded-xl bg-blue-500/10 border border-blue-400/30 hover:bg-blue-500/20 hover:border-blue-400/50 dark:bg-blue-500/20 dark:border-blue-500/40 dark:hover:bg-blue-500/30 transition-all duration-200'
         >
-          <h3 className='text-xl font-semibold text-slate-800 group-hover:text-blue-600 transition-colors'>
+          <h3 className='text-xl font-semibold text-slate-800 dark:text-slate-100 group-hover:text-blue-600 transition-colors'>
             Work Experience
           </h3>
-          <p className='mt-2 text-slate-600 text-sm'>
+          <p className='mt-2 text-slate-600 dark:text-slate-400 text-sm'>
             Roles, skills, and the journey so far.
           </p>
-          <span className='mt-4 inline-flex items-center gap-2 text-blue-600 font-medium text-sm'>
+          <span className='mt-4 inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 font-medium text-sm'>
             View timeline
             <img src={arrow} className='w-4 h-4' alt="" />
           </span>
@@ -63,22 +63,22 @@ const About = () => {
 
         <Link
           to="/blog"
-          className='group flex flex-col p-6 rounded-xl bg-blue-500/10 border border-blue-400/30 hover:bg-blue-500/20 hover:border-blue-400/50 transition-all duration-200'
+          className='group flex flex-col p-6 rounded-xl bg-blue-500/10 border border-blue-400/30 hover:bg-blue-500/20 hover:border-blue-400/50 dark:bg-blue-500/20 dark:border-blue-500/40 dark:hover:bg-blue-500/30 transition-all duration-200'
         >
-          <h3 className='text-xl font-semibold text-slate-800 group-hover:text-blue-600 transition-colors'>
+          <h3 className='text-xl font-semibold text-slate-800 dark:text-slate-100 group-hover:text-blue-600 transition-colors'>
             Blog
           </h3>
-          <p className='mt-2 text-slate-600 text-sm'>
+          <p className='mt-2 text-slate-600 dark:text-slate-400 text-sm'>
             Thoughts on design, fashion, and code.
           </p>
-          <span className='mt-4 inline-flex items-center gap-2 text-blue-600 font-medium text-sm'>
+          <span className='mt-4 inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 font-medium text-sm'>
             Read more
             <img src={arrow} className='w-4 h-4' alt="" />
           </span>
         </Link>
       </div>
       
-      <hr className='border-slate-200 mt-16'/>
+      <hr className='border-slate-200 dark:border-slate-700 mt-16'/>
       <CTA />
     </section>
   )

--- a/src/pages/AboutExperience.jsx
+++ b/src/pages/AboutExperience.jsx
@@ -5,13 +5,16 @@ import { VerticalTimeline, VerticalTimelineElement } from 'react-vertical-timeli
 import 'react-vertical-timeline-component/style.min.css'
 import CTA from '../components/CTA'
 import { arrow } from '../assets/icons'
+import { useTheme } from '../context/ThemeContext'
 
 const AboutExperience = () => {
+  const { isDark } = useTheme()
+
   return (
     <section className='max-container'>
-      <Link 
-        to="/about" 
-        className='inline-flex items-center gap-2 text-slate-600 hover:text-blue-500 mb-8 transition-colors'
+      <Link
+        to="/about"
+        className='inline-flex items-center gap-2 text-slate-600 dark:text-slate-400 hover:text-blue-500 mb-8 transition-colors'
       >
         <img src={arrow} className='w-4 h-4 rotate-180' alt="" />
         Back to About
@@ -23,7 +26,7 @@ const AboutExperience = () => {
 
       {/* Tools section - above work experience */}
       <div className='py-10 flex flex-col'>
-        <h3 className='subhead-text'>Tools & Skills</h3>
+        <h3 className='subhead-text dark:text-slate-100'>Tools & Skills</h3>
         <div className='mt-8 flex flex-wrap gap-x-8 gap-y-10'>
           {skills.map((skill) => (
             <div
@@ -50,19 +53,19 @@ const AboutExperience = () => {
 
       {/* Work experience section */}
       <div className='py-10 flex flex-col'>
-        <h3 className='subhead-text'>Work Experience</h3>
-        <div className='mt-5 flex flex-col gap-3 text-slate-500'>
+        <h3 className='subhead-text dark:text-slate-100'>Work Experience</h3>
+        <div className='mt-5 flex flex-col gap-3 text-slate-500 dark:text-slate-400'>
           <p>I've worked with all sorts of companies, levelling up my skills and teaming up with smart people. Here's the rundown:</p>
         </div>
 
         <div className='mt-12 flex'>
-          <VerticalTimeline>
+          <VerticalTimeline lineColor={isDark ? '#334155' : '#e2e8f0'}>
             {experiences.map((experience) => (
-              <VerticalTimelineElement 
+              <VerticalTimelineElement
                 key={experience.company_name}
                 date={experience.date}
                 icon={<div className='flex justify-center items-center w-full h-full'>
-                  <img 
+                  <img
                     src={experience.icon}
                     alt={experience.company_name}
                     className='w-[60%] h-[60%] object-contain'
@@ -75,14 +78,16 @@ const AboutExperience = () => {
                   borderBottom: '8px',
                   borderStyle: 'solid',
                   borderBottomColor: experience.iconBg,
-                  boxShadow: 'none'
+                  boxShadow: 'none',
+                  background: isDark ? '#1e293b' : '#fff',
+                  color: isDark ? '#e2e8f0' : 'inherit',
                 }}
               >
                 <div>
-                  <h3 className='text-black text-xl font-poppins font-semibold'>
+                  <h3 className='text-black dark:text-slate-100 text-xl font-poppins font-semibold'>
                     {experience.title}
                   </h3>
-                  <p className='text-black-500 font-medium font-base' style={{margin:0}}>
+                  <p className='text-black-500 dark:text-slate-300 font-medium font-base' style={{margin:0}}>
                     {experience.company_name}
                   </p>
                 </div>
@@ -90,21 +95,21 @@ const AboutExperience = () => {
                   {experience.points.map((point, index) =>
                     typeof point === 'object' && point.heading ? (
                       <li key={`experience-point-${index}`} className='list-none -ml-5 mt-4 mb-1'>
-                        <span className='text-black-500 font-semibold italic text-sm tracking-wide'>
+                        <span className='text-black-500 dark:text-slate-300 font-semibold italic text-sm tracking-wide'>
                           {point.heading}
                         </span>
                       </li>
                     ) : (
-                      <li key={`experience-point-${index}`} className='text-black-500/50 font-normal pl-1 text-sm'>
+                      <li key={`experience-point-${index}`} className='text-black-500/50 dark:text-slate-400 font-normal pl-1 text-sm'>
                         {point}
                       </li>
                     )
                   )}
                 </ul>
                 {experience.tools && (
-                  <div className='mt-4 pt-3 border-t border-slate-200'>
-                    <p className='text-black-500/70 font-medium text-sm mb-2'>Tools:</p>
-                    <p className='text-black-500/50 font-normal text-sm'>{experience.tools}</p>
+                  <div className='mt-4 pt-3 border-t border-slate-200 dark:border-slate-600'>
+                    <p className='text-black-500/70 dark:text-slate-400 font-medium text-sm mb-2'>Tools:</p>
+                    <p className='text-black-500/50 dark:text-slate-400 font-normal text-sm'>{experience.tools}</p>
                   </div>
                 )}
               </VerticalTimelineElement>
@@ -112,8 +117,8 @@ const AboutExperience = () => {
           </VerticalTimeline>
         </div>
       </div>
-      
-      <hr className='border-slate-200'/>
+
+      <hr className='border-slate-200 dark:border-slate-700'/>
       <CTA />
     </section>
   )

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -48,7 +48,7 @@ const Blog = () => {
     <section className='max-container'>
       <Link
         to="/about"
-        className='inline-flex items-center gap-2 text-slate-600 hover:text-blue-500 mb-8 transition-colors'
+        className='inline-flex items-center gap-2 text-slate-600 dark:text-slate-400 hover:text-blue-500 mb-8 transition-colors'
       >
         <img src={arrow} className='w-4 h-4 rotate-180' alt="" />
         Back to About
@@ -57,7 +57,7 @@ const Blog = () => {
       <h1 className='head-text'>
         <span className='blue-gradient_text font-semibold drop-shadow'>Blog</span>
       </h1>
-      <p className='mt-4 text-slate-500'>
+      <p className='mt-4 text-slate-500 dark:text-slate-400'>
         Thoughts on design, fashion, and code — straight from my Substack.
       </p>
 
@@ -83,13 +83,13 @@ const Blog = () => {
               href={post.link}
               target='_blank'
               rel='noopener noreferrer'
-              className='group block p-6 rounded-xl bg-white border border-slate-200 hover:border-blue-400/50 hover:shadow-md transition-all duration-200'
+              className='group block p-6 rounded-xl bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 hover:border-blue-400/50 dark:hover:border-blue-500/50 hover:shadow-md transition-all duration-200'
             >
               <div className='flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2'>
-                <h2 className='text-lg font-semibold text-slate-800 group-hover:text-blue-600 transition-colors'>
+                <h2 className='text-lg font-semibold text-slate-800 dark:text-slate-100 group-hover:text-blue-600 transition-colors'>
                   {post.title}
                 </h2>
-                <time className='text-sm text-slate-400 whitespace-nowrap flex-shrink-0'>
+                <time className='text-sm text-slate-400 dark:text-slate-500 whitespace-nowrap flex-shrink-0'>
                   {new Date(post.pubDate).toLocaleDateString('en-US', {
                     year: 'numeric',
                     month: 'short',
@@ -97,10 +97,10 @@ const Blog = () => {
                   })}
                 </time>
               </div>
-              <p className='mt-3 text-slate-500 text-sm leading-relaxed'>
+              <p className='mt-3 text-slate-500 dark:text-slate-400 text-sm leading-relaxed'>
                 {post.excerpt}{post.excerpt.length >= 200 ? '...' : ''}
               </p>
-              <span className='mt-4 inline-flex items-center gap-2 text-blue-600 font-medium text-sm'>
+              <span className='mt-4 inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 font-medium text-sm'>
                 Read on Substack
                 <img src={arrow} className='w-4 h-4' alt="" />
               </span>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -60,13 +60,13 @@ const Contact = () => {
         {alert.show && <Alert {...alert} />}
 
       <div className='flex-1 min-w-[50%] flex flex-col'>
-        <h1 className='head-text'>Get in Touch!</h1>
+        <h1 className='head-text dark:text-slate-100'>Get in Touch!</h1>
         
         <form 
           className='w-full flex flex-col gap-7 mt-14'
           onSubmit={handleSubmit}
         >
-          <label className='text-black-500 font-semibold'>
+          <label className='text-black-500 dark:text-slate-300 font-semibold'>
             Name
             <input
                 type="text"
@@ -80,7 +80,7 @@ const Contact = () => {
                 onBlur={handleBlur}
             />
           </label>
-          <label className='text-black-500 font-semibold'>
+          <label className='text-black-500 dark:text-slate-300 font-semibold'>
             Email
             <input
                 type="email"
@@ -94,7 +94,7 @@ const Contact = () => {
                 onBlur={handleBlur}
             />
           </label>
-          <label className='text-black-500 font-semibold'>
+          <label className='text-black-500 dark:text-slate-300 font-semibold'>
             Your Message
             <textarea
                 name="message"

--- a/src/pages/Interpreter.jsx
+++ b/src/pages/Interpreter.jsx
@@ -241,7 +241,7 @@ export default function Interpreter() {
         </span>
       </h1>
 
-      <p className="mt-5 text-slate-500 max-w-2xl">
+      <p className="mt-5 text-slate-500 dark:text-slate-400 max-w-2xl">
         An interactive playground for{' '}
         <a
           href="https://craftinginterpreters.com/the-lox-language.html"
@@ -319,7 +319,7 @@ export default function Interpreter() {
         </div>
       </div>
 
-      <p className="mt-4 text-xs text-slate-400 font-mono text-center">
+      <p className="mt-4 text-xs text-slate-400 dark:text-slate-500 font-mono text-center">
         Enter&nbsp;to run &nbsp;·&nbsp; Shift+Enter&nbsp;for newline &nbsp;·&nbsp; ↑↓&nbsp;history &nbsp;·&nbsp; Ctrl+L&nbsp;clear
       </p>
     </section>

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -11,7 +11,7 @@ const Projects = () => {
         My <span className='blue-gradient_text font-semibold drop-shadow'>Projects</span>
       </h1>
 
-      <div className='mt-5 flex flex-col gap-3 text-slate-500'>
+      <div className='mt-5 flex flex-col gap-3 text-slate-500 dark:text-slate-400'>
         <p>I've embarked on numerous projects throughout the year. Many of them are open-source, so if you come across
           something that piques your interest, feel free to explore the codebase and contribute your ideas for further enhancements.
           Your collaboration is highly valued!
@@ -33,15 +33,15 @@ const Projects = () => {
             </div>
 
             <div className='mt-5 flex flex-col'>
-              <h4 className='text-2xl font-poppins font-semibold'>{project.name}</h4>
-              <p className='mt-2 text-slate-500'>
+              <h4 className='text-2xl font-poppins font-semibold dark:text-slate-100'>{project.name}</h4>
+              <p className='mt-2 text-slate-500 dark:text-slate-400'>
                 {project.description}
               </p>
               <div className='mt-5 flex items-center gap-2 font-poppins'>
                 <Link
                   to={project.link}
                   {...(!project.link.startsWith('/') && { target: '_blank', rel: 'noopener noreferrer' })}
-                  className='font-semibold text-blue-600'
+                  className='font-semibold text-blue-600 dark:text-blue-400'
                 >
                   {project.link.startsWith('/') ? 'Try it live' : 'Live Link'}
                 </Link>
@@ -56,7 +56,7 @@ const Projects = () => {
         ))}
       </div>
 
-      <hr className='border-slate-200'/>
+      <hr className='border-slate-200 dark:border-slate-700'/>
 
       <CTA />
     </section>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Overview

This PR introduces a fully functional dark mode to the portfolio site. All content pages now support a user-toggleable dark theme with a smooth animated transition, while the 3D home page is intentionally excluded since it already renders as a dark scene.

---

## What Was Added

### Dark Mode Toggle
A sun/moon icon button appears in the navigation bar on all pages except the home page (`/`). Clicking it instantly switches the entire site between light and dark themes. The toggle is accessible with a descriptive `aria-label` that updates to reflect the current action ("Switch to dark mode" / "Switch to light mode").

### Theme Persistence
The chosen theme is saved to the browser's `localStorage`, so revisiting the site restores the user's last preference — no need to toggle again on each visit. A small inline script in the HTML head applies the saved preference before the page renders, preventing any flash of the wrong theme on load.

### Dark Blue Theme
In dark mode, the site background switches to a deep dark blue (`slate-900`), giving a sleek and consistent look across all pages:

- **About** — bio text, photo border, card links, and divider all adapt
- **Experience** — the vertical work timeline cards switch to a dark background with appropriately light text; the timeline connector line also adapts
- **Blog** — post cards shift from white to a dark surface with softer border colors
- **Projects** — project names, descriptions, links, and section dividers update accordingly
- **Contact** — page heading and form labels turn light; input and textarea fields become dark-surfaced
- **Interpreter** — the descriptive text and keyboard shortcut hint adapt (the terminal widget itself is already dark-native)

### Home Page Exclusion
Navigating to `/` always shows the correct 3D dark scene regardless of theme preference. The toggle button is hidden on the home page and the `dark` CSS class is removed from the document root while on that route, then cleanly restored when navigating away.

### Smooth Transitions
All color, background, and border changes animate over 250ms when toggling, giving the theme switch a polished, seamless feel rather than an abrupt snap.

### Icon Card Fix
The 3D skill/project icon cards previously showed a misaligned bright glow in dark mode (a light grey box shadow left over from the light theme). This has been corrected so the shadow adapts to be dark and unobtrusive in dark mode.

---

## User Experience Summary

| Situation | Behaviour |
|---|---|
| First visit | Defaults to light mode |
| Toggling | Smooth 250ms animated transition across all elements |
| Reloading | Restores saved preference instantly, no flash |
| On home page (`/`) | Toggle hidden; dark class suppressed |
| Navigating back from home | Previous theme preference restored |

---

## Testing Scenarios

### Toggle Behaviour
| Scenario | Steps | Expected Result |
|---|---|---|
| Toggle to dark mode | Open any content page → click the moon icon in the nav | All backgrounds, text, borders, and cards shift to the dark blue theme within 250ms |
| Toggle back to light | While in dark mode → click the sun icon | Site returns to the light theme with the same smooth transition |
| Toggle on each page | Visit About, Experience, Blog, Projects, Contact, Interpreter individually and toggle | Every page switches fully — no element should remain the wrong colour |

### Theme Persistence
| Scenario | Steps | Expected Result |
|---|---|---|
| Preference saved | Switch to dark mode → close the tab → reopen the site | Site loads in dark mode, no flash of light theme |
| Preference cleared | Open DevTools → Application → Local Storage → delete the `theme` key → reload | Site loads in light mode (default) |
| Private/incognito window | Open the site in a private window | Site loads in light mode; toggling works for the session but does not persist across windows |

### Home Page Exclusion
| Scenario | Steps | Expected Result |
|---|---|---|
| Toggle hidden on home | Navigate to `/` (home) | The moon/sun toggle button is not visible in the nav |
| Dark class absent on home | Navigate to `/` while dark mode is on → open DevTools → inspect `<html>` | The `dark` class is not present on the `<html>` element |
| Theme restored after home | Set dark mode → navigate to home → navigate to About | About page loads in dark mode; the toggle reappears |

### Visual Quality
| Scenario | Steps | Expected Result |
|---|---|---|
| Transition smoothness | Toggle theme on any page | All elements (text, backgrounds, borders, cards) fade simultaneously — nothing snaps or lags |
| Headings visible | Switch to dark mode on About and Projects | "Hello, I'm" and "My" (plain heading text) are white, not black |
| Icon card glow | Open Projects or Experience in dark mode → hover over a skill/project icon | No bright misaligned light patch beneath the card; shadow is dark and subtle |
| Timeline cards | Navigate to Experience in dark mode | Work history cards show a dark background with legible light text; the vertical connector line is also dark |
| Form inputs | Navigate to Contact in dark mode | Name, Email, and Message fields have a dark background with light text — not white boxes |
| Interpreter page | Navigate to Interpreter in dark mode | Descriptive text and shortcut hint are light-coloured; the terminal widget is unchanged |

### Regression Check
| Scenario | Steps | Expected Result |
|---|---|---|
| Light mode unchanged | Use the site entirely in light mode | Nothing looks different from before this PR |
| Hover animations intact | In dark mode, hover over skill icons and project cards on Experience/Projects | The 3D flip/lift animation still triggers correctly; transitions are not sluggish |
| Nav links still work | Toggle theme while on any page | Active link highlighting and hover colours on the nav remain correct |

---

## What Was Not Changed

- The home page 3D scene — intentionally unchanged
- The terminal widget on the Interpreter page — already uses a dark-native colour scheme
- The 3D icon card hover animations — unaffected by the global transition rule
- All existing light-mode styles — fully preserved; dark mode is purely additive
